### PR TITLE
Improved localization

### DIFF
--- a/Open Terminal Finder Extension/fr.lproj/Localizable.strings
+++ b/Open Terminal Finder Extension/fr.lproj/Localizable.strings
@@ -7,3 +7,5 @@
 */
 "Open a terminal" = "Ouvrir un terminal";
 "This application adds a \"Open a terminal\" item in every Finder context menus." = "Cette application ajoute une entrée  \"Ouvrir un terminal\" dans chaque menu contextuel de Finder.";
+"Information" = "Informations";
+"The specified directory does not exist" = "Le répertoire spécifié n'existe pas";

--- a/Open Terminal Finder Extension/it.lproj/Localizable.strings
+++ b/Open Terminal Finder Extension/it.lproj/Localizable.strings
@@ -1,0 +1,11 @@
+/* 
+  Localizable.strings
+  OpenTerminal
+
+  Created by Matteo Seclì on 08/11/2020.
+  Copyright © 2020 QP. All rights reserved.
+*/
+"Open a terminal" = "Apri un terminale";
+"This application adds a \"Open a terminal\" item in every Finder context menus." = "Questa applicazione aggiunge una voce \"Apri un terminale\" in ogni menu contestuale del Finder.";
+"Information" = "Informazioni";
+"The specified directory does not exist" = "La directory specificata non esiste";

--- a/Open Terminal/AppDelegate.swift
+++ b/Open Terminal/AppDelegate.swift
@@ -23,7 +23,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             if(FileManager.default.fileExists(atPath: unwrappedPath)) {
                 SwiftySystem.execute(path: "/usr/bin/open", arguments: ["-b", "com.apple.terminal", unwrappedPath])
             } else {
-                helpMe(customMessage: "The specified directory does not exist")
+                helpMe(customMessage: NSLocalizedString("The specified directory does not exist", comment:"The specified directory does not exist"))
             }
         }
         
@@ -33,13 +33,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     private func helpMe(customMessage: String) {
         let alert = NSAlert()
-        alert.messageText = "Information"
+        alert.messageText = NSLocalizedString("Information", comment:"Information")
         alert.informativeText = customMessage
         alert.runModal()
     }
     
     private func helpMe() {
-        helpMe(customMessage: "This application adds a \"Open a terminal\" item in every Finder context menus.\n\n(c) Quentin PÂRIS 2018 - http://quentin.paris")
+        helpMe(customMessage: NSLocalizedString("This application adds a \"Open a terminal\" item in every Finder context menus.", comment:"This application adds a \"Open a terminal\" item in every Finder context menus.")+"\n\n(c) Quentin PÂRIS 2016–2020 — http://quentin.paris")
     }
 }
 

--- a/OpenTerminal.xcodeproj/project.pbxproj
+++ b/OpenTerminal.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		95E7025D255D4ECA00FEFD9B /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = DD28020821275B2500C7F995 /* Localizable.strings */; };
 		DD2778DC1C7CCBB4005A1529 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD2778DB1C7CCBB4005A1529 /* AppDelegate.swift */; };
 		DD2778E01C7CCBB4005A1529 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DD2778DF1C7CCBB4005A1529 /* Assets.xcassets */; };
 		DD27791C1C7CD144005A1529 /* FinderSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD27791B1C7CD144005A1529 /* FinderSync.swift */; };
@@ -41,6 +42,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		956014962557FC8000602367 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
 		DD2778D91C7CCBB4005A1529 /* Open Terminal.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Open Terminal.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD2778DB1C7CCBB4005A1529 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		DD2778DF1C7CCBB4005A1529 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -206,9 +208,11 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 				fr,
+				it,
 			);
 			mainGroup = DD4195221C7CAA6900330823;
 			productRefGroup = DD41952C1C7CAA6900330823 /* Products */;
@@ -227,6 +231,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DD2778E01C7CCBB4005A1529 /* Assets.xcassets in Resources */,
+				95E7025D255D4ECA00FEFD9B /* Localizable.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -275,6 +280,7 @@
 			children = (
 				DD28020721275B2500C7F995 /* en */,
 				DD28020921275B3300C7F995 /* fr */,
+				956014962557FC8000602367 /* it */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";

--- a/OpenTerminal.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/OpenTerminal.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
Hello, first of all thanks for this awesome app! 🙂 

I've initially added an Italian translation for my own purposes; I then thought I could contribute it back if you like it. I've added the Italian localization of the Finder context menu, plus I've also localized (fr/it) the help messages. I noticed there was a French localization of the main help message, but it was unused.

I've no experience in GUI development and my French is also a bit rusty, so I could have messed something up. So far, though, this modified version is running smoothly on my Mac. 🙂 